### PR TITLE
chore: Update Proto specification

### DIFF
--- a/registry.proto
+++ b/registry.proto
@@ -1,0 +1,82 @@
+syntax = "proto3";
+
+option go_package = "proto_gen/";
+import "google/protobuf/timestamp.proto";
+
+package registry;
+
+service RegistryService {
+    rpc QueryArtifacts(ArtifactQuery) returns (ArtifactListResponse);
+    rpc PullArtifact(PullArtifactRequest) returns (stream ArtifactContent);
+    rpc UploadArtifact(stream UploadArtifactRequest) returns (Artifact);
+    rpc DeleteArtifact(ArtifactIdentifier) returns (Artifact);
+    rpc GetArtifact(ArtifactIdentifier) returns (Artifact);
+    rpc AddTag(AddRemoveTagRequest) returns (Artifact);
+    rpc RemoveTag(AddRemoveTagRequest) returns (Artifact);
+}
+
+message FullyQualifiedName {
+    string source = 1;
+    string author = 2;
+    string name = 3;
+}
+
+message ArtifactIdentifier {
+    FullyQualifiedName fqn = 1;
+    oneof identifier {
+        string versionHash = 2;
+        string tag = 3;
+    }
+}
+
+message Artifact {
+    FullyQualifiedName fqn = 1;
+    string versionHash = 2;
+    repeated string tags = 3;
+    MetaData metadata = 4;
+}
+
+message MetaData {
+    google.protobuf.Timestamp created = 1;
+    int64 pulls = 2;
+}
+
+message ArtifactQuery {
+    optional string source = 1;
+    optional string author = 2;
+    optional string name = 3;
+}
+
+message ArtifactListResponse {
+    repeated Artifact artifacts = 1;
+}
+
+message PullArtifactRequest {
+    FullyQualifiedName fqn = 1;
+    oneof identifier {
+        string versionHash = 2;
+        string tag = 3;
+    }
+}
+
+message ArtifactContent {
+    bytes data = 1;
+}
+
+message UploadArtifactRequest {
+    oneof request {
+        UploadMetadata metadata = 1;
+        ArtifactContent content = 2;
+    }
+}
+
+message UploadMetadata {
+    FullyQualifiedName fqn = 1;
+    repeated string tags = 2;
+}
+
+message AddRemoveTagRequest {
+    FullyQualifiedName fqn = 1;
+    string versionHash = 2;
+    string tag = 3;
+}


### PR DESCRIPTION
# Auto-Sync of Proto Specification 📋
Automated update from EnclaveRunner/artifact-registry.

This PR syncs the latest Proto specification file.

**Source commit:** a0d055c154abfe72aad8ff8a557f2ea318d9d097